### PR TITLE
feat: --stage-select add option --next

### DIFF
--- a/src/actions/packaging.rs
+++ b/src/actions/packaging.rs
@@ -149,16 +149,29 @@ pub fn packages_stage_select<'a, K: Clone + ExactSizeIterator<Item = &'a str>>(
     packages: K,
     offline: bool,
     start_package: Option<&str>,
+    is_next: bool,
 ) -> Result<i32> {
     let packages = expand_package_list(packages);
 
     let selection = if let Some(start_package) = start_package {
-        packages
+        let point = packages
             .iter()
             .position(|x| {
                 x == start_package || x.splitn(2, '/').next().unwrap_or("") == start_package
             })
-            .ok_or_else(|| anyhow!("Can not find the specified package in the list!"))?
+            .ok_or_else(|| anyhow!("Can not find the specified package in the list!"))?;
+
+        if is_next {
+            if point + 1 > packages.len() {
+                return Err(anyhow!(
+                    "The selected point is beyond the boundary of the list!"
+                ));
+            }
+
+            point + 1
+        } else {
+            point
+        }
     } else {
         eprintln!("-*-* S T A G E\t\tS E L E C T *-*-");
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,7 @@ pub fn build_cli() -> App<'static, 'static> {
                 .arg(Arg::with_name("INSTANCE").short("i").takes_value(true).help("Instance to build in"))
                 .arg(Arg::with_name("CONTINUE").conflicts_with("SELECT").short("c").long("resume").alias("continue").takes_value(true).help("Continue from a Ciel checkpoint"))
                 .arg(Arg::with_name("SELECT").max_values(1).min_values(0).long("stage-select").help("Select the starting point for a build"))
+                .arg(Arg::with_name("SELECT_NEXT").long("next").requires("SELECT").help("Build from a point below the start point"))
                 .arg(Arg::with_name("PACKAGES").conflicts_with("CONTINUE").min_values(1))
                 .about("Build the packages using the specified instance"),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,8 +227,13 @@ fn main() -> Result<()> {
             let packages = packages.unwrap();
             if args.is_present("SELECT") {
                 let start_package = args.value_of("SELECT");
-                let status =
-                    actions::packages_stage_select(&instance, packages, offline, start_package)?;
+                let status = actions::packages_stage_select(
+                    &instance,
+                    packages,
+                    offline,
+                    start_package,
+                    args.is_present("SELECT_NEXT"),
+                )?;
                 process::exit(status);
             }
             if args.is_present("FETCH") {


### PR DESCRIPTION
To build start point (x) next package (x + 1)

e.g:

I have build order file:

```
ciel-rs
apt-gen-list-rs
```

use `ciel build -i s groups/test --stage-select ciel-rs --next` to build `apt-gen-list-rs`