### PR TITLE
Use poweroff command to terminate booted container (and fix non-booted codepath)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,6 @@ dependencies = [
  "anyhow",
  "ar",
  "bincode",
- "cc",
  "clap 3.0.7",
  "clap_complete",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ dbus-codegen = "0.10"
 clap = "^3"
 clap_complete = "^3"
 anyhow = "1.0"
-cc = "1.0"
 
 [profile.release]
 lto = true

--- a/build.rs
+++ b/build.rs
@@ -36,8 +36,6 @@ fn main() {
     let machine1_machine = fs::read_to_string(MACHINE1_MACHINE_DEF).expect("");
     generate_dbus_binding(machine1, "dbus_machine1.rs");
     generate_dbus_binding(machine1_machine, "dbus_machine1_machine.rs");
-    cc::Build::new().file("src/syscall.c").compile("ciel-c");
-    println!("cargo:rerun-if-changed=src/syscall.c");
     println!("cargo:rerun-if-changed=dbus-xml/org.freedesktop.machine1.xml");
     println!("cargo:rerun-if-changed=dbus-xml/org.freedesktop.machine1-machine.xml");
     println!("cargo:rerun-if-env-changed=CIEL_GEN_COMPLETIONS");

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -28,9 +28,6 @@ const DEFAULT_NSPAWN_OPTIONS: &[&str] = &[
     "--system-call-filter=swapcontext",
 ];
 
-extern "C" {
-    fn SYS_SIGRTMIN() -> libc::c_int;
-}
 /// Instance status information
 #[derive(Debug)]
 pub struct CielInstance {
@@ -206,19 +203,6 @@ pub(crate) fn clean_child_process() {
     unsafe { waitpid(-1, &mut status, WNOHANG) };
 }
 
-fn poweroff_container(proxy: &Proxy<&Connection>) -> Result<()> {
-    // +4 for systemd poweroff signal
-    let poweroff;
-    // unsafe due to use of external functions
-    unsafe {
-        // only works with systemd
-        poweroff = SYS_SIGRTMIN() + 4;
-    }
-    proxy.kill("leader", poweroff)?;
-
-    Ok(())
-}
-
 fn kill_container(proxy: &Proxy<&Connection>) -> Result<()> {
     proxy.kill("all", libc::SIGKILL)?;
     proxy.terminate()?;
@@ -246,15 +230,9 @@ fn is_booted(proxy: &Proxy<&Connection>) -> Result<bool> {
     Ok(false)
 }
 
-fn terminate_container(proxy: &Proxy<&Connection>) -> Result<()> {
-    if !is_booted(proxy)? {
-        // with normal container, just kill it
-        kill_container(proxy)?;
-        proxy.terminate()?;
-    } else {
-        // with booted container, we want to power it off gracefully ...
-        poweroff_container(proxy)?;
-
+fn terminate_container(ns_name: &str, proxy: &Proxy<&Connection>) -> Result<()> {
+    if !execute_container_command(ns_name, &["poweroff"]).is_err() {
+        // Successfully passed poweroff command to the container, wait for it
         for _ in 0..10 {
             if proxy.state().is_err() {
                 // machine object no longer exists
@@ -265,11 +243,12 @@ fn terminate_container(proxy: &Proxy<&Connection>) -> Result<()> {
         // still did not poweroff?
         warn!("Container did not respond to the poweroff command correctly...");
         warn!("Killing the container by sending SIGKILL...");
-        // okay then, as you wish, there goes the nuke
-        kill_container(proxy)?;
-        proxy.terminate().ok();
-     }
+        // fall back to nuke
+    }
 
+    // violently kill everything inside the container
+    kill_container(proxy)?;
+    proxy.terminate().ok();
     // status re-check, in the event of I/O problems, the container may still be running (stuck)
     for _ in 0..10 {
         if proxy.state().is_err() {
@@ -289,7 +268,7 @@ pub fn terminate_container_by_name(ns_name: &str) -> Result<()> {
     let path = proxy.get_machine(ns_name)?;
     let proxy = conn.with_proxy(MACHINE1_DEST, path, Duration::from_secs(10));
 
-    terminate_container(&proxy)
+    terminate_container(ns_name, &proxy)
 }
 
 /// Mount the filesystem layers using the specified layer manager and the instance name

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -1,5 +1,0 @@
-#include <signal.h>
-
-int SYS_SIGRTMIN() {
-    return SIGRTMIN;
-}


### PR DESCRIPTION
This is friendly with qemu-user emulated containers.