### PR TITLE
cli: operation `delall` to remove all instances

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,11 @@ pub fn build_cli() -> Command<'static> {
                 .about("Remove an instance"),
         )
         .subcommand(
+            Command::new("delall")
+                .alias("rma")
+                .about("Remove all instances"),
+        )
+        .subcommand(
             Command::new("shell")
                 .alias("sh")
                 .arg(Arg::new("INSTANCE").short('i').takes_value(true).help("Instance to be used"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,9 @@ fn main() -> Result<()> {
             let instance = args.value_of("INSTANCE").unwrap();
             print_error!({ actions::remove_instance(instance) });
         }
+        ("delall", args) => {
+            print_error!({ one_or_all_instance!(args, &actions::remove_instance) });
+        }
         ("add", args) => {
             let instance = args.value_of("INSTANCE").unwrap();
             print_error!({ actions::add_instance(instance) });


### PR DESCRIPTION
The `delall` operation accepts no argument and removes all instances in a ciel workspace.