### PR TITLE
prompts: use `interact_text` instead of `interact`

### DIFF
--- a/src/actions/onboarding.rs
+++ b/src/actions/onboarding.rs
@@ -34,7 +34,7 @@ pub fn onboarding(custom_tarball: Option<&String>) -> Result<()> {
     {
         let name: String = Input::with_theme(&theme)
             .with_prompt("Name of the instance")
-            .interact()?;
+            .interact_text()?;
         init_instance = Some(name.clone());
         info!(
             "Understood. `{}` will be created after initialization is finished.",
@@ -109,7 +109,7 @@ fn auto_pick_tarball(theme: &dyn dialoguer::theme::Theme) -> Result<(String, Opt
         );
         let tarball_url = Input::<String>::with_theme(theme)
             .with_prompt("Tarball URL")
-            .interact()?;
+            .interact_text()?;
         Ok((tarball_url, None))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,7 +148,7 @@ pub fn ask_for_config(config: Option<CielConfig>) -> Result<CielConfig> {
         .with_prompt("Maintainer Information")
         .default(config.maintainer)
         .validate_with(validate_maintainer)
-        .interact()?;
+        .interact_text()?;
     config.dnssec = Confirm::with_theme(&theme)
         .with_prompt("Enable DNSSEC")
         .default(config.dnssec)


### PR DESCRIPTION
This change enables the use of arrow keys during `ciel new` and `ciel config`.

Dialoguer's documentation doesn't clearly state the difference between the two methods. When dealing with arrow key presses, `interact` records them as characters, whereas `interact_text` moves the cursor accordingly.

Demo
----
```rust
#!/usr/bin/env cargo-play

//# dialoguer = "0.10"

use dialoguer::theme::ColorfulTheme;
use dialoguer::Input;

fn main() {
    let theme = ColorfulTheme::default();
    let input: String = Input::with_theme(&theme)
        .with_prompt("Arrow keys work here")
        .interact_text()
        .unwrap();
    println!("Result: {}", input);
    let _: String = Input::with_theme(&theme)
        .with_prompt("UwU Senpai")
        .interact()
        .unwrap();
    println!("Result: {}", input);
}
```