### PR TITLE
cli,completions: use canonicalize path to find libexec location

### DIFF
--- a/completions/ciel.bash
+++ b/completions/ciel.bash
@@ -29,7 +29,7 @@ _ciel_list_packages() {
 }
 
 _ciel_list_plugins() {
-    local CIEL="$(command -v ciel)"
+    local CIEL="$(readlink -f $(command -v ciel))"
     [ -z "$CIEL" ] && return
     local PLUGIN_DIR="$(dirname $CIEL)/../libexec/ciel-plugin"
     find "$PLUGIN_DIR" -maxdepth 1 -mindepth 1 -type f -name 'ciel-*' -printf '%f\n' | cut -d'-' -f2-

--- a/completions/ciel.fish
+++ b/completions/ciel.fish
@@ -30,7 +30,7 @@ function __ciel_list_packages
 end
 
 function __ciel_list_plugins
-    set ciel_path (command -v ciel)
+    set ciel_path (readlink -f (command -v ciel))
     set ciel_plugin_dir (dirname $ciel_path)"/../libexec/ciel-plugin"
     find "$ciel_plugin_dir" -maxdepth 1 -mindepth 1 -type f -printf '%f\t-Ciel plugin-\n' | cut -d'-' -f2-
 end

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ pub const GIT_TREE_URL: &str = "https://github.com/AOSC-Dev/aosc-os-abbs.git";
 
 /// List all the available plugins/helper scripts
 fn list_helpers() -> Result<Vec<String>> {
-    let exe_dir = std::env::current_exe()?;
+    let exe_dir = std::env::current_exe().and_then(std::fs::canonicalize)?;
     let exe_dir = exe_dir.parent().ok_or_else(|| anyhow!("Where am I?"))?;
     let plugins_dir = exe_dir.join("../libexec/ciel-plugin/").read_dir()?;
     let plugins = plugins_dir


### PR DESCRIPTION
Make ciel work correctly after symlinking `${prefix}/bin/ciel` to a different place.