### PR TITLE
Add support for manually specifying architecture to `new` and `load-os`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
 dependencies = [
  "console",
+ "fuzzy-matcher",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -725,6 +726,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1724,6 +1734,16 @@ checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 console = "0.15"
 zbus = "^3"
-dialoguer = "0.10"
+dialoguer = { version = "0.10", features = ["fuzzy-select"] }
 indicatif = "0.17"
 nix = "0.26"
 lazy_static = "1.4"

--- a/src/actions/container.rs
+++ b/src/actions/container.rs
@@ -133,7 +133,7 @@ pub fn load_os(url: &str, sha256: Option<String>) -> Result<()> {
     };
     if let Some(sha256) = sha256 {
         info!("Verifying tarball checksum...");
-        let tarball = fs::File::open(path)?;
+        let tarball = fs::File::open(Path::new(filename))?;
         let checksum = sha256sum(tarball)?;
         if sha256 == checksum {
             info!("Checksum verified.");

--- a/src/actions/onboarding.rs
+++ b/src/actions/onboarding.rs
@@ -25,15 +25,13 @@ pub fn onboarding(custom_tarball: Option<&String>, arch: Option<&str>) -> Result
         return Err(anyhow!("Unable to create a ciel workspace."));
     }
     info!("Before continuing, I need to ask you a few questions:");
-    let real_arch = {
-        if arch.is_none() {
-            if custom_tarball.is_none() {
-                ask_for_target_arch().unwrap()
-            } else {
-                get_host_arch_name().unwrap()
-            }
+    let real_arch = if let Some(arch) = arch {
+        arch
+    } else {
+        if let Some(_custom_tarball) = custom_tarball {
+            get_host_arch_name().unwrap()
         } else {
-            arch.unwrap()
+            ask_for_target_arch().unwrap()
         }
     };
     let config = config::ask_for_config(None)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,7 @@ pub fn build_cli() -> Command {
         .subcommand(
             Command::new("load-os")
                 .arg(Arg::new("url").help("URL or path to the tarball"))
+                .arg(Arg::new("arch").short('a').long("arch").help("Specify the target architecture for fetching OS tarball"))
                 .about("Unpack OS tarball or fetch the latest BuildKit from the repository"),
         )
         .subcommand(Command::new("update-os").about("Update the OS in the container"))
@@ -63,6 +64,7 @@ pub fn build_cli() -> Command {
         .subcommand(
             Command::new("new")
             .arg(Arg::new("tarball").num_args(1).long("from-tarball").help("Create a new workspace from the specified tarball"))
+            .arg(Arg::new("arch").num_args(1).short('a').long("arch").help("Create a new workspace for specified architecture"))
             .about("Create a new CIEL workspace")
         )
         .subcommand(

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,21 +188,16 @@ fn main() -> Result<()> {
             }
             // load from network using auto picked url
             let specified_arch = args.get_one::<String>("arch");
-            if specified_arch.is_some() {
-                let unwrapped_arch = specified_arch.unwrap();
-                if !check_arch_name(unwrapped_arch.as_str()) {
-                    unsupported_target_architecture!(unwrapped_arch);
+            let arch = if let Some(specified_arch) = specified_arch {
+                if !check_arch_name(specified_arch.as_str()) {
+                    unsupported_target_architecture(specified_arch.as_str());
                 }
-            }
-            let arch = {
-                if specified_arch.is_none() {
-                    if !user_attended() {
-                        host_arch
-                    } else {
-                        ask_for_target_arch().unwrap()
-                    }
+                specified_arch
+            } else {
+                if !user_attended() {
+                    host_arch
                 } else {
-                    specified_arch.unwrap().as_str()
+                    ask_for_target_arch().unwrap()
                 }
             };
             info!("No URL specified. Ciel will automatically pick one.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,8 @@ macro_rules! one_or_all_instance {
     }};
 }
 
-macro_rules! unsupported_target_architecture {
-    ($arch:ident) => {
-        error!("Unknown target architecture {}", $arch);
+fn unsupported_target_architecture(arch: &str) {
+        error!("Unknown target architecture {}", arch);
         error!("Supported target architectures: {:?}",
             CIEL_MAINLINE_ARCHS.iter().map(|x| {
                 format!("{x}")
@@ -52,7 +51,6 @@ macro_rules! unsupported_target_architecture {
             })).collect::<Vec<_>>());
         error!("If you do want to load an OS unsupported by Ciel, specify a tarball to initialize this workspace.");
         process::exit(1);
-    };
 }
 
 fn get_output_dir() -> String {
@@ -239,7 +237,7 @@ fn main() -> Result<()> {
         ("new", args) => {
             let arch = args.get_one::<String>("arch").and_then(|val| {
                 if !check_arch_name(val) {
-                    unsupported_target_architecture!(val);
+                    unsupported_target_architecture(val.as_str());
                 }
                 Some(val.as_str())
             });


### PR DESCRIPTION
With this PR users can now specify the target architecture when creating a Ciel workspace using `ciel new`, and when loading OS tarball using `ciel load-os`.

- The target architecture specified is only used to determine what OS tarball to be downloaded automatically if the user chooses to let Ciel decide.
- Supported architectures are hard-coded, so if AOSC OS ever introduces a new port, this should be updated.
- If architecture is not specified when running `ciel new`, Ciel will ask the user for the desired target architecture.
- If architecture is specified when running `ciel new`, Ciel will skip this question.
- If any custom tarball is specified when running `ciel load-os`, Ciel will not ask for the target architecture.

Fixes #17.