### PR TITLE
feat: support config reuse in workspace initialization.

### DIFF
--- a/src/actions/onboarding.rs
+++ b/src/actions/onboarding.rs
@@ -1,11 +1,7 @@
 use anyhow::{anyhow, Result};
 use console::{style, user_attended, Term};
 use dialoguer::{theme::ColorfulTheme, Confirm, Input};
-use std::{
-    fs::{self, File},
-    path::Path,
-    process::exit,
-};
+use std::{fs, path::Path, process::exit};
 
 use crate::{
     actions::get_branch_name,

--- a/src/actions/onboarding.rs
+++ b/src/actions/onboarding.rs
@@ -103,7 +103,7 @@ pub fn onboarding(custom_tarball: Option<&String>, arch: Option<&str>) -> Result
     load_os(&rootfs_url, rootfs_sha256, use_tarball)?;
     info!("Initializing ABBS tree...");
     // use README.md to detect if TREE is actually initialized
-    if Path::new("TREE/README.md").is_dir() {
+    if Path::new("TREE/README.md").exists() {
         warn!("TREE already exists, skipping this step...");
     } else {
         // if TREE is a file, then remove it

--- a/src/actions/onboarding.rs
+++ b/src/actions/onboarding.rs
@@ -1,7 +1,11 @@
 use anyhow::{anyhow, Result};
 use console::{style, user_attended, Term};
 use dialoguer::{theme::ColorfulTheme, Confirm, Input};
-use std::{fs, path::Path, process::exit};
+use std::{
+    fs::{self, File},
+    path::Path,
+    process::exit,
+};
 
 use crate::{
     actions::get_branch_name,
@@ -26,10 +30,22 @@ pub fn onboarding(custom_tarball: Option<&String>, arch: Option<&str>) -> Result
 
     let theme = ColorfulTheme::default();
     info!("Welcome to ciel!");
+    // make configuration reusable
+    let mut reuse_config = false;
     if Path::new(".ciel").exists() {
-        error!("Seems like you've already created a ciel workspace here.");
-        info!("Please run `ciel farewell` to nuke it before running this command.");
-        return Err(anyhow!("Unable to create a ciel workspace."));
+        info!("Seems like you've already created a ciel workspace here.");
+        if Path::new(".ciel/data/config.toml").exists() {
+            reuse_config = Confirm::with_theme(&theme)
+                .with_prompt("Would you like to reuse configuration?")
+                .interact()?;
+        }
+        if reuse_config {
+            info!("Reusing existing configuration.");
+            // return Ok(());
+        } else {
+            info!("Please run `ciel farewell` to nuke it before running this command.");
+            return Err(anyhow!("Unable to create a ciel workspace."));
+        }
     }
     info!("Before continuing, I need to ask you a few questions:");
     let real_arch = if let Some(arch) = arch {
@@ -39,7 +55,11 @@ pub fn onboarding(custom_tarball: Option<&String>, arch: Option<&str>) -> Result
     } else {
         ask_for_target_arch()?
     };
-    let config = config::ask_for_config(None)?;
+    let config = if reuse_config {
+        config::read_config()?
+    } else {
+        config::ask_for_config(None)?
+    };
     let mut init_instance: Option<String> = None;
     if user_attended()
         && Confirm::with_theme(&theme)
@@ -60,6 +80,14 @@ pub fn onboarding(custom_tarball: Option<&String>, arch: Option<&str>) -> Result
 
     info!("Initializing workspace...");
     ciel_init()?;
+    // apply config in an earlier stage of initialization
+    config::apply_config(CIEL_DIST_DIR, &config)?;
+    info!("Applying configurations...");
+    fs::write(
+        Path::new(CIEL_DATA_DIR).join("config.toml"),
+        config.save_config()?,
+    )?;
+    info!("Configurations applied.");
     info!("Initializing container OS...");
     let (rootfs_url, rootfs_sha256, use_tarball) = match custom_tarball {
         Some(rootfs) => {
@@ -78,20 +106,16 @@ pub fn onboarding(custom_tarball: Option<&String>, arch: Option<&str>) -> Result
     };
     load_os(&rootfs_url, rootfs_sha256, use_tarball)?;
     info!("Initializing ABBS tree...");
-    if Path::new("TREE").is_dir() {
+    // use README.md to detect if TREE is actually initialized
+    if Path::new("TREE/README.md").is_dir() {
         warn!("TREE already exists, skipping this step...");
     } else {
         // if TREE is a file, then remove it
         fs::remove_file("TREE").ok();
+        // if TREE is a directory, then also remove it
+        fs::remove_dir_all("TREE").ok();
         download_git(GIT_TREE_URL, Path::new("TREE"))?;
     }
-    config::apply_config(CIEL_DIST_DIR, &config)?;
-    info!("Applying configurations...");
-    fs::write(
-        Path::new(CIEL_DATA_DIR).join("config.toml"),
-        config.save_config()?,
-    )?;
-    info!("Configurations applied.");
     let cwd = std::env::current_dir()?;
     let mut output_dir_name = "OUTPUT".to_string();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ pub fn build_cli() -> Command {
         .action(clap::ArgAction::Set);
     Command::new("ciel")
         .version(env!("CARGO_PKG_VERSION"))
-        .about("CIEL! is a nspawn container manager")
+        .about("CIEL! is an nspawn container manager")
         .allow_external_subcommands(true)
         .subcommand(Command::new("version").about("Display the version of CIEL!"))
         .subcommand(Command::new("init")


### PR DESCRIPTION
This commit adds an option to reuse configuration created before, making `ciel new` in bad network smoother (asking less questions).
In order to reuse configuration, the writing process of config becomes earlier, now after workspace initialization.
Also, a simple TREE checker is added to ensure the clone process of TREE is actually done.
This commit also fixed a typo in `cli.rs` because 'n' in "nspawn" should be pronounced in vowel.